### PR TITLE
add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @the-fast-tracked-programmer/mentors


### PR DESCRIPTION
#### Motivation (Why)

Team members are not able to request reviewers currently, as raised in our [#first-contributions](https://discord.com/channels/815407176734212126/883128186391629834/883351349473984553) discord channel..

One possible solution may be to add a [CODEOWNERS](https://github.blog/2017-07-06-introducing-code-owners/) file to the repository, so that the mentor team can be assigned as a reviewer automatically.